### PR TITLE
feat: start cobra CLI app for metrics 🚀

### DIFF
--- a/metrics/cmd/root.go
+++ b/metrics/cmd/root.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Prefix for application specific environment variables
+const envPrefix = "RRM_METRICS_"
+
+// Repo for which to retrieve metrics
+type Repo struct {
+	Owner string
+	Name  string
+}
+
+// Options for the cmd
+type Options struct {
+	Out  io.Writer
+	Repo *Repo
+}
+
+// newRootCmd creates a new base command for the metrics CLI app
+func newRootCmd(w io.Writer) *cobra.Command {
+	opts := &Options{
+		Out: w,
+		Repo: &Repo{
+			Owner: os.Getenv(envPrefix + "REPO_OWNER"),
+			Name:  os.Getenv(envPrefix + "REPO_NAME"),
+		},
+	}
+
+	rootCmd := &cobra.Command{
+		Use:   "metrics",
+		Short: "Retrieve software delivery performance metrics",
+		Long:  "Retrieve software delivery performance metrics",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Repo.Owner == "" {
+				return fmt.Errorf("Repo.Owner is required. Set env var or pass flag.")
+			}
+			if opts.Repo.Name == "" {
+				return fmt.Errorf("Repo.Name is required. Set env var or pass flag.")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRoot(opts)
+		},
+	}
+
+	rootCmd.PersistentFlags().StringVarP(&opts.Repo.Owner, "repo-owner", "o", opts.Repo.Owner, "owner of the GitHub repo")
+	rootCmd.PersistentFlags().StringVarP(&opts.Repo.Name, "repo-name", "n", opts.Repo.Name, "name of the GitHub repo")
+
+	return rootCmd
+}
+
+// runRoot performs the action for the metrics CLI command
+func runRoot(opts *Options) error {
+	if _, err := fmt.Fprintf(opts.Out, "Retrieving metrics for %s/%s\n", opts.Repo.Owner, opts.Repo.Name); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Execute the CLI application and write errors to os.Stderr
+func Execute() {
+	rootCmd := newRootCmd(os.Stdout)
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/metrics/cmd/root_test.go
+++ b/metrics/cmd/root_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type testCase struct {
+	// Name of the test case
+	name string
+
+	// Environment variables to be set for the test case
+	env map[string]string
+
+	// Arguments to be passed to the CLI app
+	args []string
+
+	// Expected output from the CLI app
+	output string
+
+	// Text expected in error. Empty string means no error expected.
+	errContains string
+}
+
+func TestRoot(t *testing.T) {
+	repo := &Repo{Owner: "hackebrot", Name: "turtle"}
+
+	t.Setenv("RRM_METRICS_REPO_OWNER", "")
+	t.Setenv("RRM_METRICS_REPO_NAME", "")
+
+	tests := []testCase{{
+		name:        "repo__short",
+		args:        []string{"-o", repo.Owner, "-n", repo.Name},
+		output:      fmt.Sprintf("Retrieving metrics for %v/%v", repo.Owner, repo.Name),
+		errContains: "",
+	}, {
+		name:        "repo__long",
+		args:        []string{"--repo-owner", repo.Owner, "--repo-name", repo.Name},
+		output:      fmt.Sprintf("Retrieving metrics for %v/%v", repo.Owner, repo.Name),
+		errContains: "",
+	}, {
+		name:        "read_env__name",
+		env:         map[string]string{"RRM_METRICS_REPO_NAME": "hello"},
+		args:        []string{"--repo-owner", repo.Owner},
+		output:      fmt.Sprintf("Retrieving metrics for %v/%v", repo.Owner, "hello"),
+		errContains: "",
+	}, {
+		name:        "read_env__owner",
+		env:         map[string]string{"RRM_METRICS_REPO_OWNER": "mozilla"},
+		args:        []string{"--repo-name", repo.Name},
+		output:      fmt.Sprintf("Retrieving metrics for %v/%v", "mozilla", repo.Name),
+		errContains: "",
+	}, {
+		name:        "missing_value__owner",
+		args:        []string{"--repo-name", repo.Name},
+		errContains: "Repo.Owner is required",
+	}, {
+		name:        "missing_value__name",
+		args:        []string{"--repo-owner", repo.Owner},
+		errContains: "Repo.Name is required",
+	}}
+
+	runTests(t, tests)
+}
+
+// executeCmd creates and executes the metrics rood cmd
+func executeCmd(args []string) (string, error) {
+	buf := new(bytes.Buffer)
+
+	root := newRootCmd(buf)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+
+	err := root.Execute()
+
+	return buf.String(), err
+}
+
+// runTests is a helper for table-driven tests using subtests
+func runTests(t *testing.T, tests []testCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("running: metrics %s", strings.Join(tt.args, " "))
+
+			if tt.env != nil {
+				t.Logf("using environment: %s", tt.env)
+				for k, v := range tt.env {
+					t.Setenv(k, v)
+				}
+			}
+
+			got, err := executeCmd(tt.args)
+
+			if tt.errContains != "" && err == nil {
+				t.Fatalf("cmd did not return an error. output: %v", got)
+			}
+
+			if tt.errContains == "" && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if tt.errContains != "" && err != nil && !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("error did not contain message\ngot:     %v\nmissing: %v", err, tt.errContains)
+			}
+
+			if tt.output != "" {
+				tGot := strings.TrimSpace(got)
+				tWant := strings.TrimSpace(tt.output)
+
+				if !cmp.Equal(tGot, tWant) {
+					t.Fatalf("cmd returned unexpected output\ngot:  %v\nwant: %v", tGot, tWant)
+				}
+			}
+		})
+	}
+}

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,0 +1,13 @@
+module github.com/mozilla-services/rapid-release-model/metrics
+
+go 1.21.3
+
+require (
+	github.com/google/go-cmp v0.6.0
+	github.com/spf13/cobra v1.7.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/metrics/go.sum
+++ b/metrics/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/metrics/main.go
+++ b/metrics/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/mozilla-services/rapid-release-model/metrics/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
This pull request adds a minimal CLI application built with Go and [cobra](https://github.com/spf13/cobra).

We will use this app to collect service delivery performance metrics for Mozilla services on GitHub by querying the GraphQL API. The next pull requests will be adding CI configuration, application code to retrieve information about release artifacts and application code to persist the data to CSV or JSON files.