### PR TITLE
feat: Add pre-commit configuration for use locally and as a GitHub Action

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -1,0 +1,25 @@
+name: pre-commit
+
+on:
+- pull_request
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v2
+      - run: python -m pip install pre-commit
+        shell: bash
+      - run: python -m pip freeze --local
+        shell: bash
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: pre-commit run --show-diff-on-failure --color=always --all-files
+        shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: go-test-metrics
+        name: run go test on metrics/
+        language: system
+        entry: bash -c 'cd metrics && exec go test -v ./...'
+        pass_filenames: false
+        types: [go]
+        files: ^metrics/
+    -   id: go-build-metrics
+        name: run go build on metrics/
+        language: system
+        entry: bash -c 'cd metrics && exec go build -v ./...'
+        pass_filenames: false
+        types: [go]
+        files: ^metrics/


### PR DESCRIPTION
We have been using pre-commit to run a variety of safety checks, linting, etc. 

This change would add the same build and test steps but as a pre-commit that could be installed locally and ran on other go projects or extended to other pre-commit hooks. https://pre-commit.com/hooks.html