### PR TITLE
chore: updated checkout version in precommit workflow

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: python -m pip install pre-commit
         shell: bash
       - run: python -m pip freeze --local


### PR DESCRIPTION
> Just noticed we're using a more recent version of the `checkout` action in the `Go` workflow.
> 
> Can we update this to use the same version, @dlactin?
> 
> https://github.com/mozilla-services/rapid-release-model/blob/main/.github/workflows/precommit.yaml#L11



Updated checkout action version to match other workflows 