### PR TITLE
docs: add Mozilla Code of Conduct 📋

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Community Participation Guidelines
+
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
+
+For more details, please read the [Mozilla Community Participation Guidelines][cpg].
+
+## How to Report
+
+For more information on how to report violations of the Community Participation
+Guidelines, please read our [How to Report][reporting] page.
+
+[reporting]: https://www.mozilla.org/about/governance/policies/participation/reporting/
+[cpg]: https://www.mozilla.org/about/governance/policies/participation/


### PR DESCRIPTION
Copied from https://github.com/mozilla-services/.github/blob/master/CODE_OF_CONDUCT.md and reformatted Markdown.