### PR TITLE
Query deployments from Grafana REST API 📦 

### DIFF
--- a/metrics/cmd/deployments_test.go
+++ b/metrics/cmd/deployments_test.go
@@ -57,15 +57,25 @@ func TestDeployments(t *testing.T) {
 		WantFile:    filepath.Join(tempDir, "r.json"),
 		Env:         env,
 	}, {
-		Name:          "deployments__env__single",
-		Args:          []string{"github", "-o", repo.Owner, "-n", repo.Name, "deployments", "--env", "prod"},
-		WantVariables: map[string]interface{}{"environments": []githubv4.String{githubv4.String("prod")}},
-		Env:           env,
+		Name: "deployments__env__single",
+		Args: []string{"github", "-o", repo.Owner, "-n", repo.Name, "deployments", "--env", "prod"},
+		WantReqParams: &test.WantReqParams{
+			GitHub: &test.GitHubReqParams{
+				Variables: map[string]interface{}{
+					"environments": []githubv4.String{githubv4.String("prod")}},
+			},
+		},
+		Env: env,
 	}, {
-		Name:          "deployments__env__multiple",
-		Args:          []string{"github", "-o", repo.Owner, "-n", repo.Name, "deployments", "--env", "prod", "--env", "hello"},
-		WantVariables: map[string]interface{}{"environments": []githubv4.String{githubv4.String("prod"), githubv4.String("hello")}},
-		Env:           env,
+		Name: "deployments__env__multiple",
+		Args: []string{"github", "-o", repo.Owner, "-n", repo.Name, "deployments", "--env", "prod", "--env", "hello"},
+		WantReqParams: &test.WantReqParams{
+			GitHub: &test.GitHubReqParams{
+				Variables: map[string]interface{}{
+					"environments": []githubv4.String{githubv4.String("prod"), githubv4.String("hello")}},
+			},
+		},
+		Env: env,
 	}}
 
 	test.RunTests(t, newRootCmd, tests)

--- a/metrics/cmd/grafana/deployments.go
+++ b/metrics/cmd/grafana/deployments.go
@@ -1,0 +1,99 @@
+package grafana
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/factory"
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/grafana"
+	"github.com/spf13/cobra"
+)
+
+type DeploymentsOptions struct {
+	App   string
+	From  string
+	To    string
+	Limit int
+}
+
+func newDeploymentsCmd(f *factory.Factory) *cobra.Command {
+	opts := new(DeploymentsOptions)
+
+	cmd := &cobra.Command{
+		Use:   "deployments",
+		Short: "Retrieve data about Deployments from Grafana Annotations",
+		Long:  "Retrieve data about Deployments from Grafana Annotations",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Read annotations filter values from environment variables.
+			// Order: CLI flag default values, environment variables, CLI flag values
+			filter, err := f.NewGrafanaAnnotationsFilter()
+			if err != nil {
+				return fmt.Errorf("Error reading Grafana Annotations Filter from env: %w", err)
+			}
+
+			// This flag is required. If neither env is set or flag is given, error out.
+			if cmd.Flags().Changed("app-name") {
+				filter.App = opts.App
+			}
+
+			if filter.App == "" {
+				return fmt.Errorf("App is required. Set env var or pass flag.")
+			}
+
+			if filter.From == "" || cmd.Flags().Changed("from") {
+				filter.From = opts.From
+			}
+
+			if filter.To == "" || cmd.Flags().Changed("to") {
+				filter.To = opts.To
+			}
+
+			filter.Limit = opts.Limit
+
+			if filter.Limit < 1 {
+				return fmt.Errorf("Limit cannot be smaller than 1.")
+			}
+
+			// Overwrite the factory function to return the loaded filter values.
+			f.NewGrafanaAnnotationsFilter = func() (*grafana.AnnotationsFilter, error) {
+				return filter, nil
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDeployments(cmd.Root().Context(), f, opts)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&opts.App, "app-name", "a", "", "name of the Grafana app")
+	cmd.Flags().StringVar(&opts.From, "from", "now-6M", "epoch datetime in milliseconds (e.g. now-6M)")
+	cmd.Flags().StringVar(&opts.To, "to", "now", "epoch datetime in milliseconds (e.g. now)")
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "l", 100, "limit for how many Deployments to fetch")
+
+	return cmd
+}
+
+func runDeployments(ctx context.Context, f *factory.Factory, opts *DeploymentsOptions) error {
+	filter, err := f.NewGrafanaAnnotationsFilter()
+	if err != nil {
+		return err
+	}
+
+	client, err := f.NewGrafanaHTTPClient()
+	if err != nil {
+		return err
+	}
+
+	deployments, err := grafana.QueryDeployments(ctx, client, filter)
+	if err != nil {
+		return err
+	}
+
+	exporter, err := f.NewExporter()
+	if err != nil {
+		return err
+	}
+
+	return exporter.Export(deployments)
+}

--- a/metrics/cmd/grafana/deployments_test.go
+++ b/metrics/cmd/grafana/deployments_test.go
@@ -1,0 +1,82 @@
+package grafana
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/config"
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/test"
+)
+
+func TestDeployments(t *testing.T) {
+	env := map[string]string{
+		config.EnvKey("GRAFANA", "TOKEN"):               "",
+		config.EnvKey("GRAFANA", "SERVER_URL"):          "",
+		config.EnvKey("GRAFANA", "ANNOTATIONS", "APP"):  "",
+		config.EnvKey("GRAFANA", "ANNOTATIONS", "FROM"): "",
+		config.EnvKey("GRAFANA", "ANNOTATIONS", "TO"):   "",
+	}
+
+	tests := []test.TestCase{
+		{
+			Name:        "deployments__app_name__required",
+			Args:        []string{"deployments"},
+			ErrContains: "App is required. Set env var or pass flag",
+			Env:         env,
+		},
+		{
+			Name:        "deployments__defaults",
+			Args:        []string{"deployments", "-a", "turtle"},
+			WantFixture: test.NewFixture("api", "annotations", "want__defaults.json"),
+			WantReqParams: &test.WantReqParams{Grafana: &test.GrafanaReqParams{
+				Path: "api/annotations",
+				Params: url.Values{
+					"type":  []string{"annotation"},
+					"from":  []string{"now-6M"},
+					"to":    []string{"now"},
+					"limit": []string{"100"},
+					"tags":  []string{"event_type:deployment", "event_status:complete", "app:turtle"},
+				},
+			}},
+			Env: env,
+		},
+		{
+			Name: "deployments__env__from_to",
+			Args: []string{"deployments", "-a", "turtle"},
+			WantReqParams: &test.WantReqParams{Grafana: &test.GrafanaReqParams{
+				Path: "api/annotations",
+				Params: url.Values{
+					"type":  []string{"annotation"},
+					"from":  []string{"now-4M"},
+					"to":    []string{"now-2M"},
+					"limit": []string{"100"},
+					"tags":  []string{"event_type:deployment", "event_status:complete", "app:turtle"},
+				},
+			}},
+			Env: map[string]string{
+				config.EnvKey("GRAFANA", "ANNOTATIONS", "FROM"): "now-4M",
+				config.EnvKey("GRAFANA", "ANNOTATIONS", "TO"):   "now-2M",
+			},
+		},
+		{
+			Name: "deployments__env__from_to__overwrite",
+			Args: []string{"deployments", "-a", "turtle", "--from", "now-12M", "--to", "now-1M"},
+			WantReqParams: &test.WantReqParams{Grafana: &test.GrafanaReqParams{
+				Path: "api/annotations",
+				Params: url.Values{
+					"type":  []string{"annotation"},
+					"from":  []string{"now-12M"},
+					"to":    []string{"now-1M"},
+					"limit": []string{"100"},
+					"tags":  []string{"event_type:deployment", "event_status:complete", "app:turtle"},
+				},
+			}},
+			Env: map[string]string{
+				config.EnvKey("GRAFANA", "ANNOTATIONS", "FROM"): "now-4M",
+				config.EnvKey("GRAFANA", "ANNOTATIONS", "TO"):   "now-2M",
+			},
+		},
+	}
+
+	test.RunTests(t, NewGrafanaCmd, tests)
+}

--- a/metrics/cmd/grafana/fixtures/api/annotations/response.json
+++ b/metrics/cmd/grafana/fixtures/api/annotations/response.json
@@ -13,14 +13,14 @@
         "created": 1706064620004,
         "updated": 1706064718021,
         "timeEnd": 1706064718021,
-        "text": "test",
+        "text": "<b>Canary Deployment:<\b> turtle<br><b>Docker Image:</b> turtle:2024.01.22<br>",
         "metric": "",
         "tags": [
             "app:turtle",
-            "env:stage",
+            "env:prod",
             "event_status:complete",
             "event_type:deployment",
-            "realm:nonprod",
+            "realm:prod",
             "type:app"
         ],
         "data": {}
@@ -39,7 +39,7 @@
         "created": 1666403642123,
         "updated": 1666403642123,
         "timeEnd": 1666403642123,
-        "text": "test",
+        "text": "<b>Docker Image:</b> turtle:2022.10.02<br>",
         "metric": "",
         "tags": [
             "app:turtle",

--- a/metrics/cmd/grafana/fixtures/api/annotations/response.json
+++ b/metrics/cmd/grafana/fixtures/api/annotations/response.json
@@ -1,0 +1,54 @@
+[
+    {
+        "id": 1124,
+        "alertId": 0,
+        "dashboardId": 124,
+        "dashboardUID": null,
+        "panelId": 2,
+        "userId": 1,
+        "userName": "",
+        "newState": "",
+        "prevState": "",
+        "time": 1706064620004,
+        "created": 1706064620004,
+        "updated": 1706064718021,
+        "timeEnd": 1706064718021,
+        "text": "test",
+        "metric": "",
+        "tags": [
+            "app:turtle",
+            "env:stage",
+            "event_status:complete",
+            "event_type:deployment",
+            "realm:nonprod",
+            "type:app"
+        ],
+        "data": {}
+    },
+    {
+        "id": 1123,
+        "alertId": 0,
+        "dashboardId": 123,
+        "dashboardUID": "123abc_23",
+        "panelId": 2,
+        "userId": 1,
+        "userName": "",
+        "newState": "",
+        "prevState": "",
+        "time": 1666403642123,
+        "created": 1666403642123,
+        "updated": 1666403642123,
+        "timeEnd": 1666403642123,
+        "text": "test",
+        "metric": "",
+        "tags": [
+            "app:turtle",
+            "env:stage",
+            "event_status:complete",
+            "event_type:deployment",
+            "realm:nonprod",
+            "type:app"
+        ],
+        "data": {}
+    }
+]

--- a/metrics/cmd/grafana/fixtures/api/annotations/want__defaults.json
+++ b/metrics/cmd/grafana/fixtures/api/annotations/want__defaults.json
@@ -1,0 +1,16 @@
+[
+    {
+        "DockerImage": null,
+        "CreatedAt": "2024-01-24T02:50:20.004Z",
+        "UpdatedAt": "2024-01-24T02:51:58.021Z",
+        "Env": "",
+        "Canary": false
+    },
+    {
+        "DockerImage": null,
+        "CreatedAt": "2022-10-22T01:54:02.123Z",
+        "UpdatedAt": "2022-10-22T01:54:02.123Z",
+        "Env": "",
+        "Canary": false
+    }
+]

--- a/metrics/cmd/grafana/fixtures/api/annotations/want__defaults.json
+++ b/metrics/cmd/grafana/fixtures/api/annotations/want__defaults.json
@@ -1,16 +1,22 @@
 [
     {
-        "DockerImage": null,
+        "DockerImage": {
+            "repo": "turtle",
+            "tag": "2024.01.22"
+        },
         "CreatedAt": "2024-01-24T02:50:20.004Z",
         "UpdatedAt": "2024-01-24T02:51:58.021Z",
-        "Env": "",
-        "Canary": false
+        "Env": "prod",
+        "Canary": true
     },
     {
-        "DockerImage": null,
+        "DockerImage": {
+            "repo": "turtle",
+            "tag": "2022.10.02"
+        },
         "CreatedAt": "2022-10-22T01:54:02.123Z",
         "UpdatedAt": "2022-10-22T01:54:02.123Z",
-        "Env": "",
+        "Env": "stage",
         "Canary": false
     }
 ]

--- a/metrics/cmd/grafana/grafana.go
+++ b/metrics/cmd/grafana/grafana.go
@@ -1,0 +1,18 @@
+package grafana
+
+import (
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/factory"
+	"github.com/spf13/cobra"
+)
+
+func NewGrafanaCmd(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "grafana",
+		Short: "Retrieve metrics from Grafana",
+		Long:  "Retrieve metrics from Grafana",
+	}
+
+	cmd.AddCommand(newDeploymentsCmd(f))
+
+	return cmd
+}

--- a/metrics/cmd/root.go
+++ b/metrics/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mozilla-services/rapid-release-model/metrics/cmd/grafana"
 	"github.com/mozilla-services/rapid-release-model/metrics/internal/export"
 	"github.com/mozilla-services/rapid-release-model/metrics/internal/factory"
 	"github.com/spf13/cobra"
@@ -61,6 +62,7 @@ func newRootCmd(f *factory.Factory) *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&opts.Export.Filename, "filename", "f", "", "export to file")
 
 	rootCmd.AddCommand(newGitHubCmd(f))
+	rootCmd.AddCommand(grafana.NewGrafanaCmd(f))
 
 	return rootCmd
 }

--- a/metrics/internal/factory/factory.go
+++ b/metrics/internal/factory/factory.go
@@ -22,6 +22,7 @@ type Factory struct {
 	NewGitHubGraphQLClient      func() (github.GraphQLClient, error)
 	NewGitHubRepo               func() (*github.Repo, error)
 	NewGrafanaHTTPClient        func() (grafana.HTTPClient, error)
+	NewGrafanaAnnotationsFilter func() (*grafana.AnnotationsFilter, error)
 }
 
 // NewFactory creates the default Factory for the CLI application
@@ -79,5 +80,15 @@ func NewFactory(ctx context.Context) *Factory {
 
 		return grafana.NewClient(grafanaURL, accessToken)
 	}
+
+	f.NewGrafanaAnnotationsFilter = func() (*grafana.AnnotationsFilter, error) {
+		repo := &grafana.AnnotationsFilter{
+			App:  config.ReadFromEnv("GRAFANA", "ANNOTATIONS", "APP"),
+			From: config.ReadFromEnv("GRAFANA", "ANNOTATIONS", "FROM"),
+			To:   config.ReadFromEnv("GRAFANA", "ANNOTATIONS", "TO"),
+		}
+		return repo, nil
+	}
+
 	return f
 }

--- a/metrics/internal/factory/factory.go
+++ b/metrics/internal/factory/factory.go
@@ -9,17 +9,19 @@ import (
 	"github.com/mozilla-services/rapid-release-model/metrics/internal/config"
 	"github.com/mozilla-services/rapid-release-model/metrics/internal/export"
 	"github.com/mozilla-services/rapid-release-model/metrics/internal/github"
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/grafana"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
 
 // Factory is used to create dependencies for the CLI application
 type Factory struct {
-	NewEncoder             func() (export.Encoder, error)
-	NewExporter            func() (export.Exporter, error)
-	NewGitHubHTTPClient    func() (*http.Client, error)
-	NewGitHubGraphQLClient func() (github.GraphQLClient, error)
-	NewGitHubRepo          func() (*github.Repo, error)
+	NewEncoder                  func() (export.Encoder, error)
+	NewExporter                 func() (export.Exporter, error)
+	NewGitHubHTTPClient         func() (*http.Client, error)
+	NewGitHubGraphQLClient      func() (github.GraphQLClient, error)
+	NewGitHubRepo               func() (*github.Repo, error)
+	NewGrafanaHTTPClient        func() (grafana.HTTPClient, error)
 }
 
 // NewFactory creates the default Factory for the CLI application
@@ -64,5 +66,18 @@ func NewFactory(ctx context.Context) *Factory {
 		return repo, nil
 	}
 
+	f.NewGrafanaHTTPClient = func() (grafana.HTTPClient, error) {
+		grafanaURL, err := config.ReadFromEnvE("GRAFANA", "SERVER_URL")
+		if err != nil {
+			return nil, fmt.Errorf("Error creating Grafana HTTP Client: %w", err)
+		}
+
+		accessToken, err := config.ReadFromEnvE("GRAFANA", "TOKEN")
+		if err != nil {
+			return nil, fmt.Errorf("Error creating Grafana HTTP Client: %w", err)
+		}
+
+		return grafana.NewClient(grafanaURL, accessToken)
+	}
 	return f
 }

--- a/metrics/internal/grafana/annotations.go
+++ b/metrics/internal/grafana/annotations.go
@@ -1,0 +1,91 @@
+package grafana
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// AnnotationsFilter holds parameters for filtering Grafana Annotations
+type AnnotationsFilter struct {
+	App   string
+	From  string
+	To    string
+	Limit int
+}
+
+// CreateURLValues creates URL values based on the given AnnotationsFilter
+func CreateURLValues(f *AnnotationsFilter) url.Values {
+	values := make(url.Values)
+
+	// Fixed parameters for deployments
+	values.Add("type", "annotation")
+	values.Add("tags", "event_type:deployment")
+	values.Add("tags", "event_status:complete")
+
+	// Variable parameters specified by the user
+	values.Add("tags", fmt.Sprintf("app:%s", f.App))
+	values.Add("from", f.From)
+	values.Add("to", f.To)
+	values.Add("limit", strconv.Itoa(f.Limit))
+
+	return values
+}
+
+// Annotation represents an annotation object as returned by the Grafana REST API
+type Annotation struct {
+	Text      string   `json:"text"`
+	CreatedAt int64    `json:"created"`
+	UpdatedAt int64    `json:"updated"`
+	Time      int64    `json:"time"`
+	TimeEnd   int64    `json:"timeEnd"`
+	Tags      []string `json:"tags"`
+}
+
+// DockerImage used for a Deployment
+type DockerImage struct {
+	Repo string `json:"repo"`
+	Tag  string `json:"tag"`
+}
+
+// Deployment event referenced by a Grafana annotation
+type Deployment struct {
+	DockerImage *DockerImage
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Env         string
+	Canary      bool
+}
+
+// QueryDeployments fetches information about Deployments from the Grafana REST API
+func QueryDeployments(ctx context.Context, httpClient HTTPClient, filter *AnnotationsFilter) ([]Deployment, error) {
+	// Create HTTP request query parameters
+	urlValues := CreateURLValues(filter)
+
+	respData, err := httpClient.Get(ctx, "api/annotations", urlValues)
+	if err != nil {
+		return nil, err
+	}
+
+	var annotations []Annotation
+
+	if err := json.Unmarshal(respData, &annotations); err != nil {
+		return nil, err
+	}
+
+	var deployments []Deployment
+
+	for _, a := range annotations {
+		// TODO: Parse Docker image, environment, and canary from the annotation text
+		deployment := &Deployment{
+			CreatedAt: time.UnixMilli(a.CreatedAt).UTC(),
+			UpdatedAt: time.UnixMilli(a.UpdatedAt).UTC(),
+		}
+		deployments = append(deployments, *deployment)
+	}
+
+	return deployments, nil
+}

--- a/metrics/internal/grafana/api.go
+++ b/metrics/internal/grafana/api.go
@@ -1,0 +1,80 @@
+package grafana
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// HTTPClient is satisfied by httpClient
+type HTTPClient interface {
+	Get(ctx context.Context, p string, params url.Values) ([]byte, error)
+}
+
+// httpClient implements the HTTPClient interface
+type httpClient struct {
+	baseURL *url.URL
+	client  *http.Client
+	headers map[string]string
+}
+
+// Send an HTTP GET Request for the given URL path and Query parameters
+func (c *httpClient) Get(ctx context.Context, p string, params url.Values) ([]byte, error) {
+	// Construct the full Request URL path
+	u, err := url.JoinPath(c.baseURL.String(), p)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new HTTP Request object with the given Context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set HTTP Headers for the Request
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
+	// Set HTTP Query parameters for the Request
+	req.URL.RawQuery = params.Encode()
+
+	// Send the HTTP Request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Unexpected HTTP Response status code: %d", resp.StatusCode)
+	}
+
+	// Read and return the Response Body
+	return io.ReadAll(resp.Body)
+}
+
+// NewClient creates a new Grafana HTTP Client
+func NewClient(baseURL string, accessToken string) (*httpClient, error) {
+	// Parse the raw URL string into a URL structure
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Grafana URL: %w", err)
+	}
+
+	client := &httpClient{
+		client:  http.DefaultClient,
+		baseURL: u,
+		headers: map[string]string{
+			"User-Agent":    "Rapid-Release-Model Metrics CLI",
+			"Accept":        "application/json",
+			"Content-Type":  "application/json",
+			"Authorization": fmt.Sprintf("Bearer %s", accessToken),
+		},
+	}
+
+	return client, nil
+}

--- a/metrics/internal/test/grafana.go
+++ b/metrics/internal/test/grafana.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// GrafanaReqParams holds expected values for outgoing requests to Grafana.
+type GrafanaReqParams struct {
+	Path   string
+	Params url.Values
+}
+
+// FakeGrafanaClient returns canned responses (fixtures) rather than
+// sending queries to the live Grafana REST API.
+type FakeGrafanaClient struct {
+	reqParams *GrafanaReqParams
+}
+
+func (c *FakeGrafanaClient) Get(ctx context.Context, p string, params url.Values) ([]byte, error) {
+	if c.reqParams != nil && !cmp.Equal(p, c.reqParams.Path) {
+		return nil, fmt.Errorf("unexpected path for HTTP query\n%v", cmp.Diff(p, c.reqParams.Path))
+	}
+
+	if c.reqParams != nil && !cmp.Equal(params, c.reqParams.Params) {
+		return nil, fmt.Errorf("unexpected URL values for HTTP query\n%v", cmp.Diff(params, c.reqParams.Params))
+	}
+
+	return LoadFixture(p, "response.json")
+}

--- a/metrics/internal/test/testcase.go
+++ b/metrics/internal/test/testcase.go
@@ -10,6 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// WantReqParams holds expected values for outgoing requests to GitHub and
+// Grafana. These will be passed on to the respective fake clients and will be
+// validated against when performing a request.
+type WantReqParams struct {
+	GitHub  *GitHubReqParams
+	Grafana *GrafanaReqParams
+}
+
 type TestCase struct {
 	// Name of the test case
 	Name string
@@ -29,8 +37,8 @@ type TestCase struct {
 	// Expect output to be written to this file
 	WantFile string
 
-	// Expected values for the GraphQL query variables
-	WantVariables map[string]interface{}
+	// Expected parameters for outgoing requests to GitHub and Grafana
+	WantReqParams *WantReqParams
 
 	// Text expected in error. Empty string means no error expected.
 	ErrContains string
@@ -62,7 +70,7 @@ func RunTests(t *testing.T, newCmd func(*factory.Factory) *cobra.Command, tests 
 			}
 
 			// Execute the CLI cmd with the specified args
-			got, err := ExecuteCmd(newCmd, tt.Args, tt.WantVariables)
+			got, err := ExecuteCmd(newCmd, tt.Args, tt.WantReqParams)
 
 			if tt.ErrContains != "" && err == nil {
 				t.Fatalf("cmd did not return an error. output: %v", got)


### PR DESCRIPTION
This allows to retrieve deployment event data retroactively for some services.

Resolve #11 