### PR TITLE
Dockerize metrics CLI app 🐳 

### DIFF
--- a/metrics/.dockerignore
+++ b/metrics/.dockerignore
@@ -1,0 +1,7 @@
+# Exclude everything by default
+*
+
+# Except for Go source files and Go dependency files
+!**/*.go
+!go.mod
+!go.sum

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.22 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/metrics
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /app/metrics /app/metrics
+
+ENTRYPOINT [ "/app/metrics" ]


### PR DESCRIPTION
This adds a minimal multi-stage `Dockerfile` for the metrics CLI app.

The runtime image I've decided to use for this is `gcr.io/distroless/static-debian12:nonroot`.

For more information about the Docker base image, see https://github.com/GoogleContainerTools/distroless/.

For more information about Docker images for Go, see  https://docs.docker.com/language/golang/build-images/#multi-stage-builds.

Resolve #20 