### PR TITLE
Check for both .yml and .yaml configs 🐛 

### DIFF
--- a/ciplatforms/internal/github/api.go
+++ b/ciplatforms/internal/github/api.go
@@ -178,12 +178,14 @@ func updateRepos(batch []*Repository, data map[string]interface{}) error {
 	return nil
 }
 
-// hasYmlFile checks if any entry in the entries slice is a YAML file.
+// hasYmlFile checks if any entry in the entries slice is a YAML file with a .yml or .yaml extension.
 func hasYmlFile(entries []interface{}) bool {
 	for _, entry := range entries {
 		if entryMap, ok := entry.(map[string]interface{}); ok {
-			if name, ok := entryMap["name"].(string); ok && strings.HasSuffix(name, ".yml") {
-				return true
+			if name, ok := entryMap["name"].(string); ok {
+				if strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml") {
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Noticed in our data that at least repository that is using GitHub Actions was flagged to not use GitHub Actions as they use the`*.yaml` file extension for their workflow config files.

This fixes that in the app.