### PR TITLE
Add commit history and ref comparison 📋 

### DIFF
--- a/metrics/cmd/compare.go
+++ b/metrics/cmd/compare.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/factory"
+	"github.com/mozilla-services/rapid-release-model/pkg/github"
+	"github.com/spf13/cobra"
+)
+
+type CompareOptions struct {
+	Limit int
+	Base  string
+	Head  string
+}
+
+func newCompareCmd(f *factory.Factory) *cobra.Command {
+	opts := new(CompareOptions)
+
+	cmd := &cobra.Command{
+		Use:   "compare",
+		Short: "Retrieve commits between Git refs",
+		Long:  "Retrieve commits between Git refs",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Limit < 1 {
+				return fmt.Errorf("limit cannot be smaller than 1")
+			}
+			// TODO: add CSV encoding support for this command
+			if encoding, err := cmd.Flags().GetString("encoding"); err != nil {
+				return fmt.Errorf("failed to retrieve 'encoding' flag: %w", err)
+			} else if encoding != "json" {
+				return fmt.Errorf("unsupported Export.Encoding. Please use 'json'")
+			}
+			if opts.Base == "" || opts.Head == "" {
+				return fmt.Errorf("git Ref Base and Head are required")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompare(cmd.Root().Context(), f, opts)
+		},
+	}
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "l", 10, "limit for how many Commits to fetch")
+	cmd.Flags().StringVar(&opts.Base, "base", "", "base Git ref")
+	cmd.Flags().StringVar(&opts.Head, "head", "", "head Git ref")
+
+	return cmd
+}
+
+func runCompare(ctx context.Context, f *factory.Factory, opts *CompareOptions) error {
+	repo, err := f.NewGitHubRepo()
+	if err != nil {
+		return err
+	}
+
+	gqlClient, err := f.NewGitHubGraphQLClient()
+	if err != nil {
+		return err
+	}
+
+	commits, err := github.QueryCompareRefs(gqlClient, repo, opts.Base, opts.Head, opts.Limit)
+	if err != nil {
+		return err
+	}
+
+	exporter, err := f.NewExporter()
+	if err != nil {
+		return err
+	}
+
+	return exporter.Export(commits)
+}

--- a/metrics/cmd/fixtures/deployments/query.json
+++ b/metrics/cmd/fixtures/deployments/query.json
@@ -19,7 +19,8 @@
                     "Task": "deploy",
                     "State": "ACTIVE",
                     "Commit": {
-                        "AbbreviatedOid": "1abc111"
+                        "AbbreviatedOid": "1abc111",
+                        "Oid": "1abc111aaaaaaaaaaa"
                     }
                 },
                 {
@@ -31,7 +32,8 @@
                     "Task": "deploy",
                     "State": "ACTIVE",
                     "Commit": {
-                        "AbbreviatedOid": "1abc111"
+                        "AbbreviatedOid": "1abc111",
+                        "Oid": "1abc111aaaaaaaaaaa"
                     }
                 },
                 {
@@ -43,7 +45,8 @@
                     "Task": "deploy",
                     "State": "INACTIVE",
                     "Commit": {
-                        "AbbreviatedOid": "2abc111"
+                        "AbbreviatedOid": "2abc111",
+                        "Oid": "2abc111bbbbbbbbbbb"
                     }
                 }
             ]

--- a/metrics/cmd/fixtures/deployments/query_abc123.json
+++ b/metrics/cmd/fixtures/deployments/query_abc123.json
@@ -19,7 +19,8 @@
                     "Task": "deploy",
                     "State": "ACTIVE",
                     "Commit": {
-                        "AbbreviatedOid": "3abc111"
+                        "AbbreviatedOid": "3abc111",
+                        "Oid": "3abc111ccccccccccc"
                     }
                 }
             ]

--- a/metrics/cmd/fixtures/deployments/want__default.csv
+++ b/metrics/cmd/fixtures/deployments/want__default.csv
@@ -1,5 +1,5 @@
-description,createdAt,updatedAt,originalEnvironment,latestEnvironment,task,state,commitOid
-Deployment03,2022-05-02T20:25:05Z,2022-05-02T20:25:05Z,prod,prod,deploy,ACTIVE,1abc111
-Deployment03,2022-05-01T20:20:05Z,2022-05-01T20:20:05Z,stage,stage,deploy,ACTIVE,1abc111
-Deployment02,2022-04-01T20:25:05Z,2022-04-01T20:25:05Z,stage,stage,deploy,INACTIVE,2abc111
-Deployment01,2022-02-01T20:25:05Z,2022-02-01T20:25:05Z,hello,hello,deploy,ACTIVE,3abc111
+description,createdAt,updatedAt,originalEnvironment,latestEnvironment,task,state,abbreviatedCommitOid,commitOid
+Deployment03,2022-05-02T20:25:05Z,2022-05-02T20:25:05Z,prod,prod,deploy,ACTIVE,1abc111,1abc111aaaaaaaaaaa
+Deployment03,2022-05-01T20:20:05Z,2022-05-01T20:20:05Z,stage,stage,deploy,ACTIVE,1abc111,1abc111aaaaaaaaaaa
+Deployment02,2022-04-01T20:25:05Z,2022-04-01T20:25:05Z,stage,stage,deploy,INACTIVE,2abc111,2abc111bbbbbbbbbbb
+Deployment01,2022-02-01T20:25:05Z,2022-02-01T20:25:05Z,hello,hello,deploy,ACTIVE,3abc111,3abc111ccccccccccc

--- a/metrics/cmd/fixtures/deployments/want__default.json
+++ b/metrics/cmd/fixtures/deployments/want__default.json
@@ -8,7 +8,8 @@
         "Task": "deploy",
         "State": "ACTIVE",
         "Commit": {
-            "AbbreviatedOid": "1abc111"
+            "AbbreviatedOid": "1abc111",
+            "Oid": "1abc111aaaaaaaaaaa"
         }
     },
     {
@@ -20,7 +21,8 @@
         "Task": "deploy",
         "State": "ACTIVE",
         "Commit": {
-            "AbbreviatedOid": "1abc111"
+            "AbbreviatedOid": "1abc111",
+            "Oid": "1abc111aaaaaaaaaaa"
         }
     },
     {
@@ -32,7 +34,8 @@
         "Task": "deploy",
         "State": "INACTIVE",
         "Commit": {
-            "AbbreviatedOid": "2abc111"
+            "AbbreviatedOid": "2abc111",
+            "Oid": "2abc111bbbbbbbbbbb"
         }
     },
     {
@@ -44,7 +47,8 @@
         "Task": "deploy",
         "State": "ACTIVE",
         "Commit": {
-            "AbbreviatedOid": "3abc111"
+            "AbbreviatedOid": "3abc111",
+            "Oid": "3abc111ccccccccccc"
         }
     }
 ]

--- a/metrics/cmd/fixtures/deployments/want__limit.json
+++ b/metrics/cmd/fixtures/deployments/want__limit.json
@@ -8,7 +8,8 @@
         "Task": "deploy",
         "State": "ACTIVE",
         "Commit": {
-            "AbbreviatedOid": "1abc111"
+            "AbbreviatedOid": "1abc111",
+            "Oid": "1abc111aaaaaaaaaaa"
         }
     },
     {
@@ -20,7 +21,8 @@
         "Task": "deploy",
         "State": "ACTIVE",
         "Commit": {
-            "AbbreviatedOid": "1abc111"
+            "AbbreviatedOid": "1abc111",
+            "Oid": "1abc111aaaaaaaaaaa"
         }
     }
 ]

--- a/metrics/cmd/github.go
+++ b/metrics/cmd/github.go
@@ -35,6 +35,7 @@ func newGitHubCmd(f *factory.Factory) *cobra.Command {
 	cmd.AddCommand(newPullRequestsCmd(f))
 	cmd.AddCommand(newReleasesCmd(f))
 	cmd.AddCommand(newDeploymentsCmd(f))
+	cmd.AddCommand(newCompareCmd(f))
 
 	return cmd
 }

--- a/metrics/cmd/github.go
+++ b/metrics/cmd/github.go
@@ -36,6 +36,7 @@ func newGitHubCmd(f *factory.Factory) *cobra.Command {
 	cmd.AddCommand(newReleasesCmd(f))
 	cmd.AddCommand(newDeploymentsCmd(f))
 	cmd.AddCommand(newCompareCmd(f))
+	cmd.AddCommand(newHistoryCmd(f))
 
 	return cmd
 }

--- a/metrics/cmd/history.go
+++ b/metrics/cmd/history.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mozilla-services/rapid-release-model/metrics/internal/factory"
+	"github.com/mozilla-services/rapid-release-model/pkg/github"
+	"github.com/spf13/cobra"
+)
+
+type HistoryOptions struct {
+	Limit int
+	Base  string
+	Head  string
+}
+
+func newHistoryCmd(f *factory.Factory) *cobra.Command {
+	opts := new(HistoryOptions)
+
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "Retrieve commits in range",
+		Long:  "Retrieve commits in range",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Limit < 1 {
+				return fmt.Errorf("limit cannot be smaller than 1")
+			}
+			// TODO: add CSV encoding support for this command
+			if encoding, err := cmd.Flags().GetString("encoding"); err != nil {
+				return fmt.Errorf("failed to retrieve 'encoding' flag: %w", err)
+			} else if encoding != "json" {
+				return fmt.Errorf("unsupported Export.Encoding. Please use 'json'")
+			}
+			if opts.Base == "" || opts.Head == "" {
+				return fmt.Errorf("git base and head commits are required")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHistory(cmd.Root().Context(), f, opts)
+		},
+	}
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "l", 100, "limit for how many Commits to fetch")
+	cmd.Flags().StringVar(&opts.Base, "base", "", "base Git commit")
+	cmd.Flags().StringVar(&opts.Head, "head", "", "head Git commit")
+
+	return cmd
+}
+
+func runHistory(ctx context.Context, f *factory.Factory, opts *HistoryOptions) error {
+	repo, err := f.NewGitHubRepo()
+	if err != nil {
+		return err
+	}
+
+	gqlClient, err := f.NewGitHubGraphQLClient()
+	if err != nil {
+		return err
+	}
+
+	commits, err := github.QueryHistory(gqlClient, repo, opts.Head, opts.Base, opts.Limit)
+	if err != nil {
+		return err
+	}
+
+	exporter, err := f.NewExporter()
+	if err != nil {
+		return err
+	}
+
+	return exporter.Export(commits)
+}

--- a/metrics/internal/export/encoder.go
+++ b/metrics/internal/export/encoder.go
@@ -185,6 +185,7 @@ func DeploymentsToCSVRecords(ds []github.Deployment) [][]string {
 		"latestEnvironment",
 		"task",
 		"state",
+		"abbreviatedCommitOid",
 		"commitOid",
 	})
 
@@ -197,8 +198,9 @@ func DeploymentsToCSVRecords(ds []github.Deployment) [][]string {
 			d.OriginalEnvironment,
 			d.LatestEnvironment,
 			d.Task,
-			d.State,
+			string(d.State),
 			d.Commit.AbbreviatedOid,
+			d.Commit.Oid,
 		}
 		records = append(records, record)
 	}

--- a/pkg/github/commits.go
+++ b/pkg/github/commits.go
@@ -1,0 +1,15 @@
+package github
+
+import (
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type Commit struct {
+	AbbreviatedOid githubv4.GitObjectID
+	Oid            githubv4.GitObjectID
+	AuthoredDate   time.Time
+	CommittedDate  time.Time
+	Message        string
+}

--- a/pkg/github/compare.go
+++ b/pkg/github/compare.go
@@ -1,0 +1,51 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type CompareQuery struct {
+	Repository struct {
+		Name  string
+		Owner struct {
+			Login string
+		}
+		Ref struct {
+			Compare struct {
+				Commits struct {
+					Nodes []Commit
+				} `graphql:"commits(first: $first)"`
+			} `graphql:"compare(headRef: $headRef)"`
+		} `graphql:"ref(qualifiedName: $baseRef)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+func QueryCompareRefs(gqlClient GraphQLClient, repo *Repo, base string, head string, limit int) ([]Commit, error) {
+	queryVariables := map[string]interface{}{
+		"owner":   githubv4.String(repo.Owner),
+		"name":    githubv4.String(repo.Name),
+		"baseRef": githubv4.String(base),
+		"headRef": githubv4.String(head),
+		"first":   githubv4.Int(limit),
+	}
+
+	var commits []Commit
+
+	var query CompareQuery
+
+	err := gqlClient.Query(context.Background(), &query, queryVariables)
+	if err != nil {
+		return nil, err
+	}
+
+	commits = append(commits, query.Repository.Ref.Compare.Commits.Nodes...)
+
+	if len(commits) == 0 {
+		return nil, fmt.Errorf("no commits between refs")
+	}
+
+	return commits, nil
+}

--- a/pkg/github/deployments.go
+++ b/pkg/github/deployments.go
@@ -14,9 +14,10 @@ type Deployment struct {
 	OriginalEnvironment string
 	LatestEnvironment   string
 	Task                string
-	State               string
+	State               githubv4.DeploymentState
 	Commit              struct {
 		AbbreviatedOid string
+		Oid            string
 	}
 }
 

--- a/pkg/github/history.go
+++ b/pkg/github/history.go
@@ -1,0 +1,67 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type CommitHistoryQuery struct {
+	Repository struct {
+		Object struct {
+			Commit struct {
+				History struct {
+					PageInfo struct {
+						HasNextPage bool
+						EndCursor   githubv4.String
+					}
+					Nodes []Commit
+				} `graphql:"history(first: $first, after: $endCursor)"`
+			} `graphql:"... on Commit"`
+		} `graphql:"object(oid: $oid)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+func QueryHistory(gqlClient GraphQLClient, repo *Repo, head string, base string, limit int) ([]Commit, error) {
+	var query CommitHistoryQuery
+	queryVariables := map[string]interface{}{
+		"owner":     githubv4.String(repo.Owner),
+		"name":      githubv4.String(repo.Name),
+		"oid":       githubv4.GitObjectID(head),
+		"first":     githubv4.Int(limit),
+		"endCursor": (*githubv4.String)(nil),
+	}
+
+	var commits []Commit
+
+Loop:
+	for {
+		err := gqlClient.Query(context.Background(), &query, queryVariables)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch commit history: %w", err)
+		}
+
+		for _, commit := range query.Repository.Object.Commit.History.Nodes {
+			// Stop if the base commitSHA is reached
+			if string(commit.Oid) == base {
+				return commits, nil
+			}
+
+			commits = append(commits, commit)
+
+			if len(commits) == limit {
+				break Loop
+			}
+
+		}
+
+		if !query.Repository.Object.Commit.History.PageInfo.HasNextPage {
+			break
+		}
+
+		queryVariables["endCursor"] = githubv4.String(query.Repository.Object.Commit.History.PageInfo.EndCursor)
+	}
+
+	return commits, nil
+}


### PR DESCRIPTION
This pull request introduces new commands and updates to the shared GitHub GraphQL API code in `pkg/github`.

I will combine the deployment and history functionality in the next pr, so that we can retrieve the list of deployed commits.

### New Commands:
* Added `compare` command to retrieve commits between Git refs. (`metrics/cmd/compare.go`)
* Added `history` command to retrieve commits in a specified range. (`metrics/cmd/history.go`)

Note: AI tools were used in generating this pull request 🤖